### PR TITLE
Ability to reorder columns with new `:column-order` named argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,20 @@ The default style is `banquet/styles/round`. Currently the only styles are:
 
 But it's easy to add more.
 
+```janet
+(banquet/print books :column-order [:word-count :name])
+
+# ╭────────────┬────────────────────────────╮
+# │ word-count │ name                       │
+# ├────────────┼────────────────────────────┤
+# │ 187790     │ The Fellowship of the Ring │
+# │ 156198     │ The Two Towers             │
+# │ 137115     │ The Return of the King     │
+# ╰────────────┴────────────────────────────╯
+```
+
+`:column-order` should be an array or tuple containing the same elements as your table's header row, in the order you'd like your columns to appear in the output.
+
 # API
 
 `banquet/print-rows` takes an iterable of iterables of strings.
@@ -93,7 +107,7 @@ But it's easy to add more.
 
     (banquet/print [{:x 1 :y 2} {:x 2 :y 4}])
 
-Both can take the optional named arguments `:padding`, `:separate-rows`, and `:style`.
+Both can take the optional named arguments `:padding`, `:separate-rows`, `:style`, and `:column-order`.
 
 There are lower-level helpers for formatting values and inferring headers from dicts. It's probably easiest to just read the source for those.
 
@@ -102,6 +116,7 @@ There are lower-level helpers for formatting values and inferring headers from d
 # next
 
 - renamed `print-table` to `print-rows`
+- ability to reorder columns with `:column-order` named argument
 
 # v1.0.0 2023-06-19
 

--- a/test/formatting.janet
+++ b/test/formatting.janet
@@ -75,3 +75,52 @@
   │   │ 6 │
   ╰───┴───╯
 `)
+
+(def columns-test
+  [{1 :a 2 :b 3 :c 4 :d 5 :e}
+   {3 :h 2 :g 4 :i 5 :j 1 :f}])
+
+(test-stdout (banquet/print columns-test :column-order [1 2 3 4 5]) `
+  ╭────┬────┬────┬────┬────╮
+  │ 1  │ 2  │ 3  │ 4  │ 5  │
+  ├────┼────┼────┼────┼────┤
+  │ :a │ :b │ :c │ :d │ :e │
+  │ :f │ :g │ :h │ :i │ :j │
+  ╰────┴────┴────┴────┴────╯
+`)
+
+(test-stdout (banquet/print columns-test :column-order [5 4 3 2 1]) `
+  ╭────┬────┬────┬────┬────╮
+  │ 5  │ 4  │ 3  │ 2  │ 1  │
+  ├────┼────┼────┼────┼────┤
+  │ :e │ :d │ :c │ :b │ :a │
+  │ :j │ :i │ :h │ :g │ :f │
+  ╰────┴────┴────┴────┴────╯
+`)
+
+(test-stdout (banquet/print columns-test :column-order (-> columns-test first keys sort)) `
+  ╭────┬────┬────┬────┬────╮
+  │ 1  │ 2  │ 3  │ 4  │ 5  │
+  ├────┼────┼────┼────┼────┤
+  │ :a │ :b │ :c │ :d │ :e │
+  │ :f │ :g │ :h │ :i │ :j │
+  ╰────┴────┴────┴────┴────╯
+`)
+
+(test-stdout (banquet/print columns-test :column-order (-> columns-test first keys sort reverse)) `
+  ╭────┬────┬────┬────┬────╮
+  │ 5  │ 4  │ 3  │ 2  │ 1  │
+  ├────┼────┼────┼────┼────┤
+  │ :e │ :d │ :c │ :b │ :a │
+  │ :j │ :i │ :h │ :g │ :f │
+  ╰────┴────┴────┴────┴────╯
+`)
+
+(test-error (banquet/print columns-test :column-order [5 4 3 2 :a])
+  "every value in first row must appear in `:column-order`")
+
+(test-error (banquet/print columns-test :column-order [5 4 3 2])
+  "`:column-order` must have the same length as table header")
+
+(test-error (banquet/print columns-test :column-order [5 4 3 2 1 1])
+  "`:column-order` must have the same length as table header")

--- a/test/readme.janet
+++ b/test/readme.janet
@@ -57,3 +57,13 @@
   | The Return of the King     | 137115     |
   '-----------------------------------------'
 `)
+
+(test-stdout (banquet/print books :column-order [:word-count :name]) `
+  ╭────────────┬────────────────────────────╮
+  │ word-count │ name                       │
+  ├────────────┼────────────────────────────┤
+  │ 187790     │ The Fellowship of the Ring │
+  │ 156198     │ The Two Towers             │
+  │ 137115     │ The Return of the King     │
+  ╰────────────┴────────────────────────────╯
+`)


### PR DESCRIPTION
This PR proposes a mechanism to reorder the columns of tables. 

This is accomplished by introducing a new named argument, `:column-order`, to `banquet/print-rows`. When calling `banquet/print` or `banquet/print-rows`, `:column-order` should name an array or tuple. If this array or tuple contains the same elements as the header row of the table, then the table columns will print out in that order. If not, or if the number of elements named by `:column-order` does not match the number of columns in the table, `print-rows` will raise an error.

E.g.:

```janet
(banquet/print columns-test :column-order [1 2 3 4 5])
# ╭────┬────┬────┬────┬────╮
# │ 1  │ 2  │ 3  │ 4  │ 5  │
# ├────┼────┼────┼────┼────┤
# │ :a │ :b │ :c │ :d │ :e │
# │ :f │ :g │ :h │ :i │ :j │
# ╰────┴────┴────┴────┴────╯

(banquet/print columns-test :column-order [5 4 3 2 1])
# ╭────┬────┬────┬────┬────╮
# │ 5  │ 4  │ 3  │ 2  │ 1  │
# ├────┼────┼────┼────┼────┤
# │ :e │ :d │ :c │ :b │ :a │
# │ :j │ :i │ :h │ :g │ :f │
# ╰────┴────┴────┴────┴────╯
```

New tests have been added to validate this functionalty. All previously passing tests still pass unmodified.